### PR TITLE
fix(src/plugin.ts): fixed import of doExecWithPty to load from plugin…

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,7 +14,7 @@
 import { Registrar, Arguments } from '@kui-shell/core'
 // command name changed since KUI v6
 // import {dispatchToShell} from '@kui-shell/plugin-bash-like/dist/lib/cmds/catchall'
-import { doExecWithPty } from '@kui-shell/plugin-bash-like/dist/lib/cmds/catchall'
+import { doExecWithPty } from '@kui-shell/plugin-bash-like'
 
 import * as Debug from 'debug'
 const debug = Debug('plugins/addons')


### PR DESCRIPTION
…-bash-like

The import of doExecWithPty had to be modified for how it is exported in KUI v10 plugin-bash-like.

fix for open-cluster-management/backlog/issues/12072