### PR TITLE
fix(component): update tsconfig to explicitly target ES6 with related…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 **/*.js
 **/*.js.map
 **/*.d.ts
+.DS_Store
 tsconfig.tsbuildinfo
 dist
 mdist

--- a/.npmignore
+++ b/.npmignore
@@ -7,5 +7,6 @@ src
 CHANGELOG.md
 node_modules
 .DS_Store
+Makefile
 README.md
 tsconfig.tsbuildinfo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "14"
 
 branches:
   only:
@@ -32,7 +32,6 @@ script:
   - |
       if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" ]]; then
         tsc
-        cp -r ./dist ./mdist
         rm README.md
         ls -a
         npm pack

--- a/package-lock.json
+++ b/package-lock.json
@@ -4785,7 +4785,7 @@
       "dependencies": {
         "@npmcli/arborist": {
           "version": "2.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/installed-package-contents": "^1.0.7",
@@ -4819,12 +4819,12 @@
         },
         "@npmcli/ci-detect": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@npmcli/config": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ini": "^2.0.0",
@@ -4836,7 +4836,7 @@
         },
         "@npmcli/disparity-colors": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ansi-styles": "^4.3.0"
@@ -4844,7 +4844,7 @@
         },
         "@npmcli/git": {
           "version": "2.0.9",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/promise-spawn": "^1.3.2",
@@ -4859,7 +4859,7 @@
         },
         "@npmcli/installed-package-contents": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "npm-bundled": "^1.1.1",
@@ -4868,7 +4868,7 @@
         },
         "@npmcli/map-workspaces": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/name-from-folder": "^1.0.1",
@@ -4879,7 +4879,7 @@
         },
         "@npmcli/metavuln-calculator": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cacache": "^15.0.5",
@@ -4889,7 +4889,7 @@
         },
         "@npmcli/move-file": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mkdirp": "^1.0.4",
@@ -4898,17 +4898,17 @@
         },
         "@npmcli/name-from-folder": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@npmcli/node-gyp": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@npmcli/promise-spawn": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "infer-owner": "^1.0.4"
@@ -4916,7 +4916,7 @@
         },
         "@npmcli/run-script": {
           "version": "1.8.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^1.0.2",
@@ -4928,17 +4928,17 @@
         },
         "@tootallnate/once": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "agent-base": {
           "version": "6.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "4"
@@ -4946,7 +4946,7 @@
         },
         "agentkeepalive": {
           "version": "4.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^4.1.0",
@@ -4956,7 +4956,7 @@
         },
         "aggregate-error": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "clean-stack": "^2.0.0",
@@ -4965,7 +4965,7 @@
         },
         "ajv": {
           "version": "6.12.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -4976,12 +4976,12 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -4989,27 +4989,27 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "aproba": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -5018,12 +5018,12 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
@@ -5031,32 +5031,32 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "aws4": {
           "version": "1.11.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "tweetnacl": "^0.14.3"
@@ -5064,7 +5064,7 @@
         },
         "bin-links": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cmd-shim": "^4.0.1",
@@ -5077,12 +5077,12 @@
         },
         "binary-extensions": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -5091,17 +5091,17 @@
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "byte-size": {
           "version": "7.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cacache": {
           "version": "15.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/move-file": "^1.0.1",
@@ -5125,12 +5125,12 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "chalk": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5139,12 +5139,12 @@
         },
         "chownr": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cidr-regex": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ip-regex": "^4.1.0"
@@ -5152,12 +5152,12 @@
         },
         "clean-stack": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cli-columns": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "string-width": "^2.0.0",
@@ -5166,7 +5166,7 @@
         },
         "cli-table3": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "colors": "^1.1.2",
@@ -5176,17 +5176,17 @@
           "dependencies": {
             "ansi-regex": {
               "version": "5.0.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             },
             "string-width": {
               "version": "4.2.2",
-              "bundled": true,
+              "resolved": false,
               "dev": true,
               "requires": {
                 "emoji-regex": "^8.0.0",
@@ -5196,7 +5196,7 @@
             },
             "strip-ansi": {
               "version": "6.0.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true,
               "requires": {
                 "ansi-regex": "^5.0.0"
@@ -5206,12 +5206,12 @@
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cmd-shim": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mkdirp-infer-owner": "^2.0.0"
@@ -5219,12 +5219,12 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -5232,18 +5232,18 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "colors": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
@@ -5252,7 +5252,7 @@
         },
         "combined-stream": {
           "version": "1.0.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -5260,27 +5260,27 @@
         },
         "common-ancestor-path": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -5288,7 +5288,7 @@
         },
         "debug": {
           "version": "4.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -5296,19 +5296,19 @@
           "dependencies": {
             "ms": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "defaults": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "clone": "^1.0.2"
@@ -5316,22 +5316,22 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "depd": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "asap": "^2.0.0",
@@ -5340,12 +5340,12 @@
         },
         "diff": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "jsbn": "~0.1.0",
@@ -5354,12 +5354,12 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "encoding": {
           "version": "0.1.13",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5368,42 +5368,42 @@
         },
         "env-paths": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "err-code": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fast-deep-equal": {
           "version": "3.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "form-data": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -5413,7 +5413,7 @@
         },
         "fs-minipass": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minipass": "^3.0.0"
@@ -5421,17 +5421,17 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -5446,12 +5446,12 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -5459,7 +5459,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -5471,7 +5471,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -5479,7 +5479,7 @@
         },
         "glob": {
           "version": "7.1.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -5492,17 +5492,17 @@
         },
         "graceful-fs": {
           "version": "4.2.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "har-validator": {
           "version": "5.1.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ajv": "^6.12.3",
@@ -5511,7 +5511,7 @@
         },
         "has": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
@@ -5519,17 +5519,17 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "hosted-git-info": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -5537,12 +5537,12 @@
         },
         "http-cache-semantics": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "http-proxy-agent": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@tootallnate/once": "1",
@@ -5552,7 +5552,7 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -5562,7 +5562,7 @@
         },
         "https-proxy-agent": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "agent-base": "6",
@@ -5571,7 +5571,7 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ms": "^2.0.0"
@@ -5579,7 +5579,7 @@
         },
         "iconv-lite": {
           "version": "0.6.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5588,7 +5588,7 @@
         },
         "ignore-walk": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -5596,22 +5596,22 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "indent-string": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -5620,17 +5620,17 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ini": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "init-package-json": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -5645,17 +5645,17 @@
         },
         "ip": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ip-regex": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-cidr": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cidr-regex": "^3.1.1"
@@ -5663,7 +5663,7 @@
         },
         "is-core-module": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "has": "^1.0.3"
@@ -5671,72 +5671,72 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-lambda": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-parse-even-better-errors": {
           "version": "2.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-stringify-nice": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -5747,22 +5747,22 @@
         },
         "just-diff": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "just-diff-apply": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "leven": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "libnpmaccess": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -5773,7 +5773,7 @@
         },
         "libnpmdiff": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/disparity-colors": "^1.0.1",
@@ -5788,7 +5788,7 @@
         },
         "libnpmexec": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/arborist": "^2.3.0",
@@ -5806,7 +5806,7 @@
         },
         "libnpmfund": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/arborist": "^2.5.0"
@@ -5814,7 +5814,7 @@
         },
         "libnpmhook": {
           "version": "6.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -5823,7 +5823,7 @@
         },
         "libnpmorg": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -5832,7 +5832,7 @@
         },
         "libnpmpack": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/run-script": "^1.8.3",
@@ -5842,7 +5842,7 @@
         },
         "libnpmpublish": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "normalize-package-data": "^3.0.2",
@@ -5854,7 +5854,7 @@
         },
         "libnpmsearch": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "npm-registry-fetch": "^10.0.0"
@@ -5862,7 +5862,7 @@
         },
         "libnpmteam": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -5871,7 +5871,7 @@
         },
         "libnpmversion": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/git": "^2.0.7",
@@ -5883,7 +5883,7 @@
         },
         "lru-cache": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -5891,7 +5891,7 @@
         },
         "make-fetch-happen": {
           "version": "8.0.14",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "agentkeepalive": "^4.1.3",
@@ -5913,12 +5913,12 @@
         },
         "mime-db": {
           "version": "1.47.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.30",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mime-db": "1.47.0"
@@ -5926,7 +5926,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -5934,7 +5934,7 @@
         },
         "minipass": {
           "version": "3.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -5942,7 +5942,7 @@
         },
         "minipass-collect": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minipass": "^3.0.0"
@@ -5950,7 +5950,7 @@
         },
         "minipass-fetch": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "encoding": "^0.1.12",
@@ -5961,7 +5961,7 @@
         },
         "minipass-flush": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minipass": "^3.0.0"
@@ -5969,7 +5969,7 @@
         },
         "minipass-json-stream": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "jsonparse": "^1.3.1",
@@ -5978,7 +5978,7 @@
         },
         "minipass-pipeline": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minipass": "^3.0.0"
@@ -5986,7 +5986,7 @@
         },
         "minipass-sized": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minipass": "^3.0.0"
@@ -5994,7 +5994,7 @@
         },
         "minizlib": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minipass": "^3.0.0",
@@ -6003,12 +6003,12 @@
         },
         "mkdirp": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mkdirp-infer-owner": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "chownr": "^2.0.0",
@@ -6018,17 +6018,17 @@
         },
         "ms": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "node-gyp": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
@@ -6045,7 +6045,7 @@
         },
         "nopt": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "abbrev": "1"
@@ -6053,7 +6053,7 @@
         },
         "normalize-package-data": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
@@ -6064,7 +6064,7 @@
         },
         "npm-audit-report": {
           "version": "2.1.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "chalk": "^4.0.0"
@@ -6072,7 +6072,7 @@
         },
         "npm-bundled": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
@@ -6080,7 +6080,7 @@
         },
         "npm-install-checks": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "semver": "^7.1.1"
@@ -6088,12 +6088,12 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "npm-package-arg": {
           "version": "8.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
@@ -6103,7 +6103,7 @@
         },
         "npm-packlist": {
           "version": "2.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "glob": "^7.1.6",
@@ -6114,7 +6114,7 @@
         },
         "npm-pick-manifest": {
           "version": "6.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "npm-install-checks": "^4.0.0",
@@ -6125,7 +6125,7 @@
         },
         "npm-profile": {
           "version": "5.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "npm-registry-fetch": "^10.0.0"
@@ -6133,7 +6133,7 @@
         },
         "npm-registry-fetch": {
           "version": "10.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0",
@@ -6147,12 +6147,12 @@
         },
         "npm-user-validate": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -6163,22 +6163,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -6186,12 +6186,12 @@
         },
         "opener": {
           "version": "1.5.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-map": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "aggregate-error": "^3.0.0"
@@ -6199,7 +6199,7 @@
         },
         "pacote": {
           "version": "11.3.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@npmcli/git": "^2.0.1",
@@ -6225,7 +6225,7 @@
         },
         "parse-conflict-json": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.0",
@@ -6235,47 +6235,47 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "proc-log": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "promise-all-reject-late": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "promise-call-limit": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "promise-retry": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "err-code": "^2.0.2",
@@ -6284,7 +6284,7 @@
         },
         "promzard": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "read": "1"
@@ -6292,27 +6292,27 @@
         },
         "psl": {
           "version": "1.8.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "punycode": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
@@ -6320,12 +6320,12 @@
         },
         "read-cmd-shim": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "read-package-json": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -6336,7 +6336,7 @@
         },
         "read-package-json-fast": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.0",
@@ -6345,7 +6345,7 @@
         },
         "readable-stream": {
           "version": "2.3.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6359,7 +6359,7 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -6370,7 +6370,7 @@
         },
         "request": {
           "version": "2.88.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -6397,7 +6397,7 @@
           "dependencies": {
             "tough-cookie": {
               "version": "2.5.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true,
               "requires": {
                 "psl": "^1.1.28",
@@ -6408,7 +6408,7 @@
         },
         "resolve": {
           "version": "1.20.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-core-module": "^2.2.0",
@@ -6417,12 +6417,12 @@
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "rimraf": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -6430,17 +6430,17 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "semver": {
           "version": "7.3.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -6448,22 +6448,22 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "smart-buffer": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "socks": {
           "version": "2.6.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ip": "^1.1.5",
@@ -6472,7 +6472,7 @@
         },
         "socks-proxy-agent": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "agent-base": "6",
@@ -6482,7 +6482,7 @@
         },
         "spdx-correct": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -6491,12 +6491,12 @@
         },
         "spdx-exceptions": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -6505,12 +6505,12 @@
         },
         "spdx-license-ids": {
           "version": "3.0.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "sshpk": {
           "version": "1.16.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "asn1": "~0.2.3",
@@ -6526,7 +6526,7 @@
         },
         "ssri": {
           "version": "8.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minipass": "^3.1.1"
@@ -6534,7 +6534,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -6543,12 +6543,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -6558,7 +6558,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -6566,12 +6566,12 @@
         },
         "stringify-package": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6579,7 +6579,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -6587,7 +6587,7 @@
         },
         "tar": {
           "version": "6.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "chownr": "^2.0.0",
@@ -6600,22 +6600,22 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "treeverse": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -6623,12 +6623,12 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "typedarray-to-buffer": {
           "version": "3.1.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-typedarray": "^1.0.0"
@@ -6636,7 +6636,7 @@
         },
         "unique-filename": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "unique-slug": "^2.0.0"
@@ -6644,7 +6644,7 @@
         },
         "unique-slug": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
@@ -6652,7 +6652,7 @@
         },
         "uri-js": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "punycode": "^2.1.0"
@@ -6660,17 +6660,17 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "uuid": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -6679,7 +6679,7 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "builtins": "^1.0.3"
@@ -6687,7 +6687,7 @@
         },
         "verror": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -6697,12 +6697,12 @@
         },
         "walk-up-path": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "wcwidth": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "defaults": "^1.0.3"
@@ -6710,7 +6710,7 @@
         },
         "which": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -6718,7 +6718,7 @@
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
@@ -6726,12 +6726,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "write-file-atomic": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
@@ -6742,7 +6742,7 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@kui-shell/plugin-kui-addons",
   "version": "0.0.0-semantically-released",
   "description": "",
-  "main": "index.js",
+  "main": "dist/plugin.js",
+  "module": "mdist/plugin.js",
+  "types": "mdist/plugin.d.ts",
   "private": true,
   "scripts": {
     "semantic-release": "semantic-release",

--- a/tsconfig-es6.json
+++ b/tsconfig-es6.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "outDir": "mdist",
-    "module": "esnext"
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,13 @@
   "extends": "./node_modules/@kui-shell/builder/tsconfig-base.json",
   "include": ["./src"],
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "downlevelIteration": true,
     "composite": true,
-    "outDir": "dist",
+    "outDir": "mdist",
     "rootDir": "src",
+    "module": "esnext",
+    "target": "ES2016",
     "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
… changes

Old version of this plugin was packaging the plugin differently than for an explicit ES6 target and
resulting content in mdist directory.

BREAKING CHANGE: This plugin is now built and packaged differently targeting ES6 and output in mdist
instead of dist

fix for open-cluster-management/backlog/issues/12072