### PR TITLE
refactor(component): host Kui notebooks in this plugin

### DIFF
--- a/notebooks/welcome.json
+++ b/notebooks/welcome.json
@@ -1,0 +1,132 @@
+{
+  "apiVersion": "kui-shell/v1",
+  "kind": "Notebook",
+  "metadata": {
+    "name": "Getting Started",
+    "description": "Getting started with Visual Web Terminal"
+  },
+  "spec": {
+    "splits": [
+      {
+        "uuid": "1_c57e811f-2da8-557e-a402-9f0950407675",
+        "blocks": [
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "# Visual Web Terminal\n\n## About\n\nThe Visual Web Terminal offers a new development experience for building cloud-native applications by combining the power of various CLIs with the convenience of visualizations. The Visual Web Terminal enables you to run commands from various tools, display and navigate complex `JSON` and `YAML` data models, and view operational data. Built using the KUI open source project code: https://github.com/kubernetes-sigs/kui.\n\n## Getting Started\n\nThe Visual Web Terminal is an interface that combines the convenience of a graphical user interface with the speed of a command-line interface. After running a command, the data is returned in an interactive table format that can display more detail about an item when you select that item in the table.\n\nIn addition to commands that are specific to the Visual Web Terminal, the following commands are also supported:\n* Selected basic `bash` commands\n* `helm` commands\n* `kubectl` commands\n* `oc` commands\n\n### **Applications**\n\nYou can view and access information about the applications in your environment by using `kubectl` commands with the Visual Web Terminal.\n\n* Show all applications:\n\n```\nkubectl get applications\n```\n\n * Show all deployments:\n \n ```\n kubectl get deployments\n ```\n \n * Show all channels:\n \n ```\n kubectl get channels\n ```\n \n ### **Search**\n  \nYou can search for a string or attribute across your entire connected cloud management environment by using the `search` command. You can narrow your search results with filters by adding them to the end of your search command.\n\nThe `search` command returns results that are categorized by type in a table format. You can sort the data in the table by selecting the column heading for the data that you want to use to sort.\n\nTo view additional details about an item that was returned in the table, select the name of the item.\n\n* Example of a search for an IP address:\n\n```\nsearch 192.0.0.1\n```\n\n* Example of a search using resource `kind` filter:\n\n```\nsearch kind:deployment\n```\n\n* Example of a search using `owner` filter:\n```\nsearch owner:jdoe\n```\n\n* Example of a search using multiple filters:\n\n```\nsearch kind:deployment owner:jdoe\n```\n"
+              }
+            },
+            "historyIdx": 5,
+            "cwd": "~",
+            "command": "# # Visual Web Terminal\\n\\n## About\\n\\nThe Visual Web Terminal offers a new development experience for building cloud-native applications by combining the power of various CLIs with the convenience of visualizations. The Visual Web Terminal enables you to run commands from various tools, display and navigate complex `JSON` and `YAML` data models, and view operational data. Built using the KUI open source project code: https://github.com/kubernetes-sigs/kui.\\n\\n## Getting Started\\n\\nThe Visual Web Terminal is an interface that combines the convenience of a graphical user interface with the speed of a command-line interface. After running a command, the data is returned in an interactive table format that can display more detail about an item when you select that item in the table.\\n\\nIn addition to commands that are specific to the Visual Web Terminal, the following commands are also supported:\\n* Selected basic `bash` commands\\n* `helm` commands\\n* `kubectl` commands\\n* `oc` commands\\n\\n### **Applications**\\n\\nYou can view and access information about the applications in your environment by using `kubectl` commands with the Visual Web Terminal.\\n\\n* Show all applications:\\n\\n```\\nkubectl get applications\\n```\\n\\n * Show all deployments:\\n \\n ```\\n kubectl get deployments\\n ```\\n \\n * Show all channels:\\n \\n ```\\n kubectl get channels\\n ```\\n \\n ### **Search**\\n  \\nYou can search for a string or attribute across your entire connected cloud management environment by using the `search` command. You can narrow your search results with filters by adding them to the end of your search command.\\n\\nThe `search` command returns results that are categorized by type in a table format. You can sort the data in the table by selecting the column heading for the data that you want to use to sort.\\n\\nTo view additional details about an item that was returned in the table, select the name of the item.\\n\\n* Example of a search for an IP address:\\n\\n```\\nsearch 192.0.0.1\\n```\\n\\n* Example of a search using resource `kind` filter:\\n\\n```\\nsearch kind:deployment\\n```\\n\\n* Example of a search using `owner` filter:\\n```\\nsearch owner:jdoe\\n```\\n\\n* Example of a search using multiple filters:\\n\\n```\\nsearch kind:deployment owner:jdoe\\n```\\n",
+            "startEvent": {
+              "route": "/#",
+              "startTime": 1623119437931,
+              "command": "# # Visual Web Terminal\\n\\n## About\\n\\nThe Visual Web Terminal offers a new development experience for building cloud-native applications by combining the power of various CLIs with the convenience of visualizations. The Visual Web Terminal enables you to run commands from various tools, display and navigate complex `JSON` and `YAML` data models, and view operational data. Built using the KUI open source project code: https://github.com/kubernetes-sigs/kui.\\n\\n## Getting Started\\n\\nThe Visual Web Terminal is an interface that combines the convenience of a graphical user interface with the speed of a command-line interface. After running a command, the data is returned in an interactive table format that can display more detail about an item when you select that item in the table.\\n\\nIn addition to commands that are specific to the Visual Web Terminal, the following commands are also supported:\\n* Selected basic `bash` commands\\n* `helm` commands\\n* `kubectl` commands\\n* `oc` commands\\n\\n### **Applications**\\n\\nYou can view and access information about the applications in your environment by using `kubectl` commands with the Visual Web Terminal.\\n\\n* Show all applications:\\n\\n```\\nkubectl get applications\\n```\\n\\n * Show all deployments:\\n \\n ```\\n kubectl get deployments\\n ```\\n \\n * Show all channels:\\n \\n ```\\n kubectl get channels\\n ```\\n \\n ### **Search**\\n  \\nYou can search for a string or attribute across your entire connected cloud management environment by using the `search` command. You can narrow your search results with filters by adding them to the end of your search command.\\n\\nThe `search` command returns results that are categorized by type in a table format. You can sort the data in the table by selecting the column heading for the data that you want to use to sort.\\n\\nTo view additional details about an item that was returned in the table, select the name of the item.\\n\\n* Example of a search for an IP address:\\n\\n```\\nsearch 192.0.0.1\\n```\\n\\n* Example of a search using resource `kind` filter:\\n\\n```\\nsearch kind:deployment\\n```\\n\\n* Example of a search using `owner` filter:\\n```\\nsearch owner:jdoe\\n```\\n\\n* Example of a search using multiple filters:\\n\\n```\\nsearch kind:deployment owner:jdoe\\n```\\n",
+              "pipeStages": {
+                "prefix": "",
+                "stages": [
+                  [
+                    "#"
+                  ]
+                ],
+                "redirect": ""
+              },
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--base-url",
+                      "alias": "-b",
+                      "docs": "Base URL for images"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "noCoreRedirect": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "46696b43-791e-4516-8a7f-1c949eefd084",
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "46696b43-791e-4516-8a7f-1c949eefd084",
+                "history": 5,
+                "env": {}
+              }
+            },
+            "completeEvent": {
+              "execType": 0,
+              "completeTime": 1623119437937,
+              "command": "# # Visual Web Terminal\\n\\n## About\\n\\nThe Visual Web Terminal offers a new development experience for building cloud-native applications by combining the power of various CLIs with the convenience of visualizations. The Visual Web Terminal enables you to run commands from various tools, display and navigate complex `JSON` and `YAML` data models, and view operational data. Built using the KUI open source project code: https://github.com/kubernetes-sigs/kui.\\n\\n## Getting Started\\n\\nThe Visual Web Terminal is an interface that combines the convenience of a graphical user interface with the speed of a command-line interface. After running a command, the data is returned in an interactive table format that can display more detail about an item when you select that item in the table.\\n\\nIn addition to commands that are specific to the Visual Web Terminal, the following commands are also supported:\\n* Selected basic `bash` commands\\n* `helm` commands\\n* `kubectl` commands\\n* `oc` commands\\n\\n### **Applications**\\n\\nYou can view and access information about the applications in your environment by using `kubectl` commands with the Visual Web Terminal.\\n\\n* Show all applications:\\n\\n```\\nkubectl get applications\\n```\\n\\n * Show all deployments:\\n \\n ```\\n kubectl get deployments\\n ```\\n \\n * Show all channels:\\n \\n ```\\n kubectl get channels\\n ```\\n \\n ### **Search**\\n  \\nYou can search for a string or attribute across your entire connected cloud management environment by using the `search` command. You can narrow your search results with filters by adding them to the end of your search command.\\n\\nThe `search` command returns results that are categorized by type in a table format. You can sort the data in the table by selecting the column heading for the data that you want to use to sort.\\n\\nTo view additional details about an item that was returned in the table, select the name of the item.\\n\\n* Example of a search for an IP address:\\n\\n```\\nsearch 192.0.0.1\\n```\\n\\n* Example of a search using resource `kind` filter:\\n\\n```\\nsearch kind:deployment\\n```\\n\\n* Example of a search using `owner` filter:\\n```\\nsearch owner:jdoe\\n```\\n\\n* Example of a search using multiple filters:\\n\\n```\\nsearch kind:deployment owner:jdoe\\n```\\n",
+              "argvNoOptions": [
+                "#"
+              ],
+              "parsedOptions": {
+                "_": [
+                  "#"
+                ]
+              },
+              "pipeStages": {
+                "prefix": "",
+                "stages": [
+                  [
+                    "#"
+                  ]
+                ],
+                "redirect": ""
+              },
+              "execUUID": "46696b43-791e-4516-8a7f-1c949eefd084",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "noCoreRedirect": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "46696b43-791e-4516-8a7f-1c949eefd084",
+                "history": 5,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "# Visual Web Terminal\n\n## About\n\nThe Visual Web Terminal offers a new development experience for building cloud-native applications by combining the power of various CLIs with the convenience of visualizations. The Visual Web Terminal enables you to run commands from various tools, display and navigate complex `JSON` and `YAML` data models, and view operational data. Built using the KUI open source project code: https://github.com/kubernetes-sigs/kui.\n\n## Getting Started\n\nThe Visual Web Terminal is an interface that combines the convenience of a graphical user interface with the speed of a command-line interface. After running a command, the data is returned in an interactive table format that can display more detail about an item when you select that item in the table.\n\nIn addition to commands that are specific to the Visual Web Terminal, the following commands are also supported:\n* Selected basic `bash` commands\n* `helm` commands\n* `kubectl` commands\n* `oc` commands\n\n### **Applications**\n\nYou can view and access information about the applications in your environment by using `kubectl` commands with the Visual Web Terminal.\n\n* Show all applications:\n\n```\nkubectl get applications\n```\n\n * Show all deployments:\n \n ```\n kubectl get deployments\n ```\n \n * Show all channels:\n \n ```\n kubectl get channels\n ```\n \n ### **Search**\n  \nYou can search for a string or attribute across your entire connected cloud management environment by using the `search` command. You can narrow your search results with filters by adding them to the end of your search command.\n\nThe `search` command returns results that are categorized by type in a table format. You can sort the data in the table by selecting the column heading for the data that you want to use to sort.\n\nTo view additional details about an item that was returned in the table, select the name of the item.\n\n* Example of a search for an IP address:\n\n```\nsearch 192.0.0.1\n```\n\n* Example of a search using resource `kind` filter:\n\n```\nsearch kind:deployment\n```\n\n* Example of a search using `owner` filter:\n```\nsearch owner:jdoe\n```\n\n* Example of a search using multiple filters:\n\n```\nsearch kind:deployment owner:jdoe\n```\n"
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 5
+            },
+            "isExperimental": false,
+            "isReplay": true,
+            "execUUID": "46696b43-791e-4516-8a7f-1c949eefd084",
+            "originalExecUUID": "46696b43-791e-4516-8a7f-1c949eefd084",
+            "startTime": 1623119437931,
+            "outputOnly": true,
+            "state": "valid-response"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1423,6 +1423,79 @@
         }
       }
     },
+    "@kui-shell/plugin-core-support": {
+      "version": "10.3.17",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-10.3.17.tgz",
+      "integrity": "sha512-1YYQAeC+9HjrhCmvWUuyXeml5XNjDv3stmnffilGIbqLBGraC464bNEm/n2UO8TOBSmaB85+T5kpoSmOomivcA==",
+      "dev": true,
+      "requires": {
+        "@supercharge/promise-pool": "1.7.0",
+        "colors": "1.4.0",
+        "debug": "4.3.1",
+        "micromatch": "4.0.4",
+        "tmp": "0.2.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "@kui-shell/xterm-helpers": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@kui-shell/xterm-helpers/-/xterm-helpers-1.0.1.tgz",
@@ -1844,6 +1917,12 @@
           "dev": true
         }
       }
+    },
+    "@supercharge/promise-pool": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-1.7.0.tgz",
+      "integrity": "sha512-OpnF7oqk6asrOUMhldnDju4RKeZ/iMAfw3LIoLdcTI53RZJLiQ9vEAcGW+bcBELXkiPhT7RqtuPSXAFF2iAmbg==",
+      "dev": true
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@kui-shell/builder": "~10.3.4",
     "@kui-shell/core": "~10.3.4",
     "@kui-shell/plugin-bash-like": "~10.3.4",
+    "@kui-shell/plugin-core-support": "~10.3.4",
     "@types/debug": "4.1.5",
     "@types/lodash": "^4.14.135",
     "@types/node": "12.12.31",

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Contributors to the Open Cluster Management project
+ */
+
+import { notebookVFS } from '@kui-shell/plugin-core-support'
+
+export default function preloadNotebooks() {
+    notebookVFS.cp(undefined, ['plugin://plugin-kui-addons/notebooks/welcome.json'], '/kui')
+}


### PR DESCRIPTION
Kui notebooks for user help were going to be in kui-web-terminal but it makes sense to move them
here and then reference them in kui-web-terminal

fix for open-cluster-management/backlog/issues/12072